### PR TITLE
Support Vaadin 14.4.3+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>selection-grid-flow-root</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>selection-grid-flow</module>
@@ -13,12 +13,12 @@
     <description>selection-grid-flow</description>
     
     <properties>
-        <vaadin.version>14.3.8</vaadin.version>
+        <vaadin.version>14.4.4</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <selection-grid-flow.version>0.2.0</selection-grid-flow.version>
+        <selection-grid-flow.version>0.3.0</selection-grid-flow.version>
     </properties>
     <inceptionYear>2020</inceptionYear>
     <organization>

--- a/selection-grid-flow-demo/pom.xml
+++ b/selection-grid-flow-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>selection-grid-flow-demo</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
 
     <name>Selection Grid Demo</name>
     <packaging>war</packaging>
@@ -18,7 +18,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>14.3.8</vaadin.version>
+        <vaadin.version>14.4.4</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -106,7 +106,7 @@
        <dependency>
            <groupId>com.vaadin.componentfactory</groupId>
            <artifactId>selection-grid-flow</artifactId>
-           <version>0.2.0</version>
+           <version>0.3.0</version>
        </dependency>
 
         <dependency>

--- a/selection-grid-flow/pom.xml
+++ b/selection-grid-flow/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>selection-grid-flow</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <packaging>jar</packaging>
 
     <name>Selection Grid</name>
@@ -19,7 +19,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>14.3.8</vaadin.version>
+        <vaadin.version>14.4.4</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/vcf-selection-grid.js
+++ b/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/vcf-selection-grid.js
@@ -60,26 +60,26 @@ class VcfSelectionGridElement extends ElementMixin(ThemableMixin(GridElement)) {
 
     }
 
-
-    focusOnCell(rowNumber, cellNumber) {
-        if (rowNumber < 0 || cellNumber < 0) {
-            throw "index out of bound";
+    focusOnCell(rowNumber, cellNumber, nbOfCalls = 1) {
+        if (nbOfCalls < 11) { // dont make an infinite loop
+            if (rowNumber < 0 || cellNumber < 0) {
+                throw "index out of bound";
+            }
+            this.scrollToIndex(rowNumber);
+            /** workaround when the expanded node opens children the index is outside the grid size
+             * https://github.com/vaadin/vaadin-grid/issues/2060
+             * Remove this once this is fixed
+             **/
+            if (rowNumber > this._effectiveSize) {
+                const that = this;
+                setTimeout(() => {
+                    that.focusOnCell(rowNumber, cellNumber, nbOfCalls + 1);
+                }, 200);
+            } else {
+                this._startToFocus(rowNumber, cellNumber);
+            }
+            /** End of workaround **/
         }
-        this.scrollToIndex(rowNumber);
-        /** workaround when the expanded node opens children the index is outside the grid size
-         * https://github.com/vaadin/vaadin-grid/issues/2060
-         * Remove this once this is fixed
-         **/
-        if (rowNumber > this._effectiveSize) {
-            const that = this;
-            setTimeout(() => {
-                that.scrollToIndex(rowNumber);
-                that._startToFocus(rowNumber, cellNumber);
-            }, 200);
-        } else {
-            this._startToFocus(rowNumber, cellNumber);
-        }
-        /** End of workaround **/
     };
 
     _startToFocus(rowNumber, cellNumber) {


### PR DESCRIPTION
Remove the workaround for https://github.com/vaadin/vaadin-grid/issues/1820 because it has been fixed.

The workaround is incompatible with Vaadin 14.4.3+
Fix an issue if the tree node is not opened at the end of the treegrid and the expand is too slow.

Fixes #12 