### PR TITLE
V24 proposed fix

### DIFF
--- a/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionGrid.java
+++ b/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionGrid.java
@@ -112,8 +112,8 @@ public class SelectionGrid<T> extends Grid<T> {
      */
     public void focusOnCell(T item, Column<T> column) {
         int index = getIndexForItem(item);
-        if (index > 0) {
-            int colIndex = (column != null) ? getColumns().indexOf(column) : 0;
+        if (index >= 0) {
+            int colIndex = (column != null) ? getColumns().indexOf(column) : 1;
             // delay the call of focus on cell if it's used on the same round trip (grid creation + focusCell)
             this.getElement().executeJs("setTimeout(function() { $0.focusOnCell($1, $2) });", getElement(), index, colIndex);
         }

--- a/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/selection-grid.js
+++ b/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/selection-grid.js
@@ -20,6 +20,24 @@
 customElements.whenDefined("vaadin-selection-grid").then(() => {
     const Grid = customElements.get("vaadin-selection-grid");
     if (Grid) {
+        const oldOnContextMenuHandler = Grid.prototype._onContextMenu;
+        Grid.prototype._onContextMenu = function _onContextMenu(e) {
+
+            const tr = e.composedPath().find((p) => p.nodeName === "TR");
+            if (tr && typeof tr.index != 'undefined') {
+                const item = tr._item;
+                const index = tr.index;
+                if (this.selectedItems && this.selectedItems.some((i) => i.key === item.key)) {
+                    // in case current row selected, do nothing, else
+                } else {
+                    this._selectionGridSelectRow(e);
+                }
+            }
+
+            const boundOnConextMenuHandler = oldOnContextMenuHandler.bind(this);
+            boundOnConextMenuHandler(e);
+        }
+
         const oldClickHandler = Grid.prototype._onClick;
         Grid.prototype._onClick = function _click(e) {
             const boundOldClickHandler = oldClickHandler.bind(this);


### PR DESCRIPTION
* Should the index not start with 0 for the focusOnCell() ? 
* The context menu typically clears the selection and selects the underlying on, in case the underlying is not part of the current selection