### PR TITLE
chore: Bump to V24.3.0 and force war-plugin version to fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <description>selection-grid-flow</description>
     
     <properties>
-        <vaadin.version>24.0.2</vaadin.version>
+        <vaadin.version>24.3.0</vaadin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -42,6 +42,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
     <repositories>
         <repository>
             <id>Vaadin Directory</id>
@@ -71,4 +72,5 @@
             <releases><enabled>false</enabled></releases>
         </pluginRepository>
     </pluginRepositories>
+    
 </project>

--- a/selection-grid-flow-demo/pom.xml
+++ b/selection-grid-flow-demo/pom.xml
@@ -18,7 +18,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>24.0.2</vaadin.version>
+        <vaadin.version>24.3.0</vaadin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -87,7 +87,6 @@
     </dependencies>
 
     <build>
-
         <resources>
             <resource>
                 <directory>src/main/java</directory>
@@ -99,6 +98,16 @@
             </resource>
         </resources>
         <plugins>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+
             <!-- Jetty plugin for easy testing without a server -->
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>

--- a/selection-grid-flow/pom.xml
+++ b/selection-grid-flow/pom.xml
@@ -19,7 +19,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>24.0.2</vaadin.version>
+        <vaadin.version>24.3.0</vaadin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Project did not build using `mvn clean install` until war plugin version was forced for the demo. Vaadin version bumped to 24.3.0.