### PR TITLE
Fix IndexOutOfBoundsException

### DIFF
--- a/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionGrid.java
+++ b/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionGrid.java
@@ -180,7 +180,7 @@ public class SelectionGrid<T> extends Grid<T> {
 		int from = Math.min(fromIndex, toIndex);
 		int to = Math.max(fromIndex, toIndex) + 1;
 		int pageSize = dataCommunicator.getPageSize();
-		if (to - from < (pageSize * 2) - 3) {
+		if (dataCommunicator.getItemCount() > 0 && to - from < (pageSize * 2) - 3) {
 			// if the range to be retrieved is smaller than 2 pages
 			// ask the dataCommunicator to retrieve the items so the cache is used
 			for(int i = from; i < to; i++) {


### PR DESCRIPTION
Fix for #59

dataCommunicator may be empty at the time beforeClientResponse runs. So use the fallback-path like it worked before the performance improvement (#54).