### PR TITLE
refactor!: Upgrade to Vaadin 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>selection-grid-flow-root</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>selection-grid-flow</module>
@@ -11,14 +11,14 @@
     </modules>
     <name>selection-grid-flow</name>
     <description>selection-grid-flow</description>
-    
+
     <properties>
-        <vaadin.version>24.3.0</vaadin.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <vaadin.version>25.0.0-beta1</vaadin.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <selection-grid-flow.version>3.0.3</selection-grid-flow.version>
+        <selection-grid-flow.version>4.0.0</selection-grid-flow.version>
     </properties>
     <inceptionYear>2020</inceptionYear>
     <organization>
@@ -72,5 +72,5 @@
             <releases><enabled>false</enabled></releases>
         </pluginRepository>
     </pluginRepositories>
-    
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <description>selection-grid-flow</description>
 
     <properties>
-        <vaadin.version>25.0.0-beta1</vaadin.version>
+        <vaadin.version>25.0-SNAPSHOT</vaadin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <description>selection-grid-flow</description>
 
     <properties>
-        <vaadin.version>25.0-SNAPSHOT</vaadin.version>
+        <vaadin.version>25.0.0-beta4</vaadin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.vaadin.componentfactory</groupId>
@@ -18,7 +21,6 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <selection-grid-flow.version>4.0.0</selection-grid-flow.version>
     </properties>
     <inceptionYear>2020</inceptionYear>
     <organization>
@@ -29,11 +31,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>selection-grid-flow</artifactId>
-                <version>${selection-grid-flow.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-bom</artifactId>
                 <type>pom</type>
@@ -42,6 +39,19 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Jetty plugin for easy testing without a server -->
+                <plugin>
+                    <groupId>org.eclipse.jetty.ee10</groupId>
+                    <artifactId>jetty-ee10-maven-plugin</artifactId>
+                    <version>12.0.23</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
     <repositories>
         <repository>
@@ -69,7 +79,9 @@
         <pluginRepository>
             <id>vaadin-snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
-            <releases><enabled>false</enabled></releases>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </pluginRepository>
     </pluginRepositories>
 

--- a/selection-grid-flow-demo/pom.xml
+++ b/selection-grid-flow-demo/pom.xml
@@ -18,7 +18,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>25.0.0-beta1</vaadin.version>
+        <vaadin.version>25.0-SNAPSHOT</vaadin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/selection-grid-flow-demo/pom.xml
+++ b/selection-grid-flow-demo/pom.xml
@@ -22,7 +22,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>25.0-SNAPSHOT</vaadin.version>
+        <vaadin.version>25.0.0-beta4</vaadin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/selection-grid-flow-demo/pom.xml
+++ b/selection-grid-flow-demo/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>selection-grid-flow-demo</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
 
     <name>Selection Grid Demo</name>
     <packaging>war</packaging>
@@ -18,9 +18,9 @@
     </organization>
 
     <properties>
-        <vaadin.version>24.3.0</vaadin.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <vaadin.version>25.0.0-beta1</vaadin.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -64,7 +64,9 @@
         <pluginRepository>
             <id>vaadin-snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
-            <releases><enabled>false</enabled></releases>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </pluginRepository>
     </pluginRepositories>
     <dependencies>
@@ -74,11 +76,11 @@
             <artifactId>vaadin-core</artifactId>
         </dependency>
 
-       <dependency>
-           <groupId>com.vaadin.componentfactory</groupId>
-           <artifactId>selection-grid-flow</artifactId>
-           <version>${project.version}</version>
-       </dependency>
+        <dependency>
+            <groupId>com.vaadin.componentfactory</groupId>
+            <artifactId>selection-grid-flow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -98,7 +100,7 @@
             </resource>
         </resources>
         <plugins>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -110,11 +112,10 @@
 
             <!-- Jetty plugin for easy testing without a server -->
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>11.0.14</version>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-maven-plugin</artifactId>
+                <version>12.0.23</version>
                 <configuration>
-                    <scanIntervalSeconds>-1</scanIntervalSeconds>
                     <stopKey>${project.artifactId}</stopKey>
                     <stopPort>8081</stopPort>
 
@@ -129,8 +130,8 @@
                 <artifactId>vaadin-maven-plugin</artifactId>
                 <version>${vaadin.version}</version>
                 <configuration>
-                	<requireHomeNodeExec>true</requireHomeNodeExec>
-                	<pnpmEnable>true</pnpmEnable>
+                    <requireHomeNodeExec>true</requireHomeNodeExec>
+                    <pnpmEnable>true</pnpmEnable>
                 </configuration>
                 <executions>
                     <execution>

--- a/selection-grid-flow-demo/pom.xml
+++ b/selection-grid-flow-demo/pom.xml
@@ -3,8 +3,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin.componentfactory</groupId>
+        <artifactId>selection-grid-flow-root</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
 
-    <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>selection-grid-flow-demo</artifactId>
     <version>4.0.0-SNAPSHOT</version>
 
@@ -110,15 +114,13 @@
                 </configuration>
             </plugin>
 
-            <!-- Jetty plugin for easy testing without a server -->
             <plugin>
                 <groupId>org.eclipse.jetty.ee10</groupId>
                 <artifactId>jetty-ee10-maven-plugin</artifactId>
-                <version>12.0.23</version>
                 <configuration>
                     <stopKey>${project.artifactId}</stopKey>
                     <stopPort>8081</stopPort>
-
+                    <scan>5</scan>
                     <systemProperties>
                         <vaadin.frontend.hotdeploy>true</vaadin.frontend.hotdeploy>
                     </systemProperties>

--- a/selection-grid-flow-demo/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGridViewWithCustomDataProvider.java
+++ b/selection-grid-flow-demo/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGridViewWithCustomDataProvider.java
@@ -57,7 +57,7 @@ public class SelectionTreeGridViewWithCustomDataProvider extends VerticalLayout 
         return grid;
     }
 
-    public static class DepartmentsDataProvider extends AbstractBackEndHierarchicalDataProvider<Department, Void> implements ParentItemProvider<Department> {
+    public static class DepartmentsDataProvider extends AbstractBackEndHierarchicalDataProvider<Department, Void> {
         private final DepartmentData departmentData;
 
         public DepartmentsDataProvider(DepartmentData departmentData) {
@@ -65,8 +65,8 @@ public class SelectionTreeGridViewWithCustomDataProvider extends VerticalLayout 
         }
 
         @Override
-        public Optional<Department> getParent(Department item) {
-            return Optional.ofNullable(item.getParent());
+        public Department getParent(Department item) {
+            return item.getParent();
         }
 
         @Override

--- a/selection-grid-flow-demo/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGridViewWithCustomDataProvider.java
+++ b/selection-grid-flow-demo/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGridViewWithCustomDataProvider.java
@@ -70,6 +70,11 @@ public class SelectionTreeGridViewWithCustomDataProvider extends VerticalLayout 
         }
 
         @Override
+        public int getItemIndex(Department item, HierarchicalQuery<Department, Void> query) {
+            return fetchChildrenFromBackEnd(query).toList().indexOf(item);
+        }
+
+        @Override
         protected Stream<Department> fetchChildrenFromBackEnd(HierarchicalQuery<Department, Void> query) {
             return departmentData.streamDepartments(query.getParent(), query.getOffset(), query.getLimit());
         }

--- a/selection-grid-flow/pom.xml
+++ b/selection-grid-flow/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>selection-grid-flow</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 
@@ -20,9 +20,9 @@
     </organization>
 
     <properties>
-        <vaadin.version>24.3.0</vaadin.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <vaadin.version>25.0.0-beta1</vaadin.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/selection-grid-flow/pom.xml
+++ b/selection-grid-flow/pom.xml
@@ -24,7 +24,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>25.0-SNAPSHOT</vaadin.version>
+        <vaadin.version>25.0.0-beta4</vaadin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/selection-grid-flow/pom.xml
+++ b/selection-grid-flow/pom.xml
@@ -2,9 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.vaadin.componentfactory</groupId>
+        <artifactId>selection-grid-flow-root</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>selection-grid-flow</artifactId>
     <version>4.0.0-SNAPSHOT</version>
 

--- a/selection-grid-flow/pom.xml
+++ b/selection-grid-flow/pom.xml
@@ -20,7 +20,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>25.0.0-beta1</vaadin.version>
+        <vaadin.version>25.0-SNAPSHOT</vaadin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionGrid.java
+++ b/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionGrid.java
@@ -45,7 +45,7 @@ import java.util.stream.Stream;
 @JsModule("./src/vcf-selection-grid.js")
 @JsModule("./src/selection-grid.js")
 public class SelectionGrid<T> extends Grid<T> {
-	  
+
     private Integer selectRangeOnlyFromIndex = null;
     private Set<T> selectRangeOnlySelection = new HashSet<T>();
     private boolean multiSelectionColumnVisible = false;
@@ -120,8 +120,8 @@ public class SelectionGrid<T> extends Grid<T> {
         int index = getIndexForItem(item);
         if (index > 0) {
             int colIndex = (column != null) ? getColumns().indexOf(column) : 0;
-            // delay the call of focus on cell if it's used on the same round trip (grid creation + focusCell)
-            this.getElement().executeJs("setTimeout(function() { $0.focusOnCell($1, $2) });", getElement(), index, colIndex);
+            getElement().callJsFunction("focusOnCellAfterScroll", colIndex);
+            scrollToIndex(index);
         }
     }
 
@@ -174,7 +174,7 @@ public class SelectionGrid<T> extends Grid<T> {
 			}));
         }
     }
-    
+
 	@SuppressWarnings("unchecked")
 	private Set<T> obtainNewSelectedItems(int fromIndex, int toIndex) {
 		DataCommunicator<T> dataCommunicator = super.getDataCommunicator();
@@ -216,11 +216,11 @@ public class SelectionGrid<T> extends Grid<T> {
 		int end = fromIndex < toIndex ? toIndex : fromIndex;
         GridSelectionModel<T> model = getSelectionModel();
         if (model instanceof GridMultiSelectionModel) {
-                      
+
             Set<T> newSelectedItems = new HashSet<T>();
-          
+
             int calculatedFromIndex = start;
-          
+
             // selectRangeOnlySelection will keep the items already selected so there's no unnecessary
             // call to backend done
             if (!selectRangeOnlySelection.isEmpty()) {
@@ -231,10 +231,10 @@ public class SelectionGrid<T> extends Grid<T> {
               // unnecessary call to backend is done
               if (start == firstKey && end > lastKey) {
                 calculatedFromIndex = lastKey;
-                newSelectedItems.addAll(selectRangeOnlySelection);                
+                newSelectedItems.addAll(selectRangeOnlySelection);
               }
             }
-            
+
             final int calculatedFromIndexFinal = calculatedFromIndex;
 			this.getUI().ifPresent(ui->ui.beforeClientResponse(this, (ctx)->{
 	            newSelectedItems.addAll(obtainNewSelectedItems(calculatedFromIndexFinal, end));
@@ -242,16 +242,16 @@ public class SelectionGrid<T> extends Grid<T> {
 	            oldSelectedItems.removeAll(newSelectedItems);
 	            asMultiSelect().updateSelection(newSelectedItems, oldSelectedItems);
 			}));
-            
+
             // update selectRangeOnlySelection with new selected items
             selectRangeOnlySelection = new HashSet<T>(getSelectedItems());
             selectRangeOnlyFromIndex = fromIndex;
         }
     }
-    
+
     /**
      * Select the range on click and makes sure selectRangeOnlySelection is cleared.
-     * 
+     *
      * @param fromIndex
      * @param toIndex
      */
@@ -269,9 +269,9 @@ public class SelectionGrid<T> extends Grid<T> {
 		Method fetchFromProvider;
 		int padding = 0;
 		int originalLimit = limit;
-		
+
 		if(dataCommunicator.isPagingEnabled() ) {
-			int end = offset + limit;			
+			int end = offset + limit;
 			while(true) {
 				padding = offset % limit;
 				int updatedOffset = offset - padding;
@@ -281,8 +281,8 @@ public class SelectionGrid<T> extends Grid<T> {
 				} else {
 					limit++;
 				}
-			}			
-		}		
+			}
+		}
 		try {
 			fetchFromProvider = DataCommunicator.class.getDeclaredMethod("fetchFromProvider", int.class, int.class);
 			fetchFromProvider.setAccessible(true);
@@ -340,7 +340,7 @@ public class SelectionGrid<T> extends Grid<T> {
 
 	/**
 	 * Sets the visibility of the multi selection column.
-	 * 
+	 *
 	 * @param multiSelectionColumnVisible - true to show the multi selection column, false to hide it
 	 */
 	public void setMultiSelectionColumnVisible(boolean multiSelectionColumnVisible) {
@@ -358,7 +358,7 @@ public class SelectionGrid<T> extends Grid<T> {
 
 	/**
 	 * Returns true if the checkbox selection is persistent, false otherwise.
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isPersistentCheckboxSelection() {
@@ -367,7 +367,7 @@ public class SelectionGrid<T> extends Grid<T> {
 
 	/**
 	 * Sets the checkbox selection to be persistent or not.
-	 * 
+	 *
 	 * @param persistentCheckboxSelection - true to make the checkbox selection persistent, false otherwise
 	 */
 	public void setPersistentCheckboxSelection(boolean persistentCheckboxSelection) {

--- a/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
+++ b/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
@@ -85,7 +85,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
     }
 
     /**
-     * Runs the super.onAttach and hides the multi selection column afterwards (if necessary).     * necessary).
+     * Runs the super.onAttach and hides the multi selection column afterwards (if necessary).
      *
      * @param attachEvent event
      */
@@ -162,7 +162,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
             throw new IllegalArgumentException("Item with key %s not found".formatted(endItemKey));
         }
 
-        var range = fetchItemRange(rangeStartItem, rangeEndItem);
+        var range = fetchRange(rangeStartItem, rangeEndItem);
 
         var deselectOthers = options.get("deselectOthers").asBoolean(false);
         if (deselectOthers) {
@@ -172,7 +172,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
         }
     }
 
-    private List<T> fetchItemRange(T startItem, T endItem) {
+    private List<T> fetchRange(T startItem, T endItem) {
         var items = fetchHierarchyRecursively(null);
         var startIndex = items.indexOf(startItem);
         var endIndex = items.indexOf(endItem);
@@ -194,7 +194,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
      * is not removed, but set to "hidden" explicitly.
      */
     protected void hideMultiSelectionColumn() {
-      this.setMultiSelectionColumnVisible(false);
+        this.setMultiSelectionColumnVisible(false);
     }
 
     @Override
@@ -270,7 +270,6 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
 
     /**
 	 * Returns true if the checkbox selection is persistent, false otherwise.
-	 *
 	 * @return
 	 */
 	public boolean isPersistentCheckboxSelection() {
@@ -279,7 +278,6 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
 
 	/**
 	 * Sets the checkbox selection to be persistent or not.
-	 *
 	 * @param persistentCheckboxSelection - true to make the checkbox selection persistent, false otherwise
 	 */
 	public void setPersistentCheckboxSelection(boolean persistentCheckboxSelection) {

--- a/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
+++ b/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
@@ -25,12 +25,14 @@ import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.grid.GridMultiSelectionModel;
 import com.vaadin.flow.component.grid.GridSelectionModel;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider.HierarchyFormat;
+import com.vaadin.flow.data.renderer.LitRenderer;
 import com.vaadin.flow.data.selection.SelectionModel;
+import com.vaadin.flow.function.SerializableComparator;
+import com.vaadin.flow.function.ValueProvider;
 
 import tools.jackson.databind.node.ObjectNode;
 
@@ -93,7 +95,9 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
-        initSelectionModel();
+        if (this.getSelectionModel() instanceof SelectionModel.Multi) {
+        	setMultiSelectionColumnVisible(multiSelectionColumnVisible);
+        }
     }
 
     /**
@@ -133,92 +137,93 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
         super.scrollToItem(item);
     }
 
-    private void selectRange(T startItem, T endItem, boolean deselectOthers) {
-        var items = fetchHierarchyRecursively(null);
-        var startIndex = items.indexOf(startItem);
-        var endIndex = items.indexOf(endItem);
-        var range = items.subList(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1);
-
-        if (deselectOthers) {
-            var oldSelectedItems = new HashSet<>(getSelectedItems());
-            var newSelectedItems = new HashSet<>(range);
-            oldSelectedItems.removeAll(newSelectedItems);
-            asMultiSelect().updateSelection(newSelectedItems, oldSelectedItems);
-            return;
-        }
-
-        asMultiSelect().select(range);
-    }
-
-    @Override
-    protected void setSelectionModel(GridSelectionModel<T> model, SelectionMode selectionMode) {
-        super.setSelectionModel(model, selectionMode);
-        initSelectionModel();
-    }
-
-    private void initSelectionModel() {
-        if (getSelectionModel() instanceof GridMultiSelectionModel<T>) {
-            setMultiSelectionColumnVisible(multiSelectionColumnVisible);
-
-            getElement().executeJs(
-                    """
-                            const grid = this;
-                            const selectionColumn = this.querySelector('vaadin-grid-flow-selection-column');
-                            selectionColumn.autoSelect = true;
-                            selectionColumn._selectItem = function (item) {
-                                grid.$server.selectionTreeGridToggleItem(
-                                    grid.getItemId(item),
-                                    true,
-                                    this._activeModifierKeys
-                                );
-                            }
-                            selectionColumn._deselectItem = function(item) {
-                                grid.$server.selectionTreeGridToggleItem(
-                                    grid.getItemId(item),
-                                    false,
-                                    this._activeModifierKeys
-                                );
-                            }
-                            """);
-        }
-    }
-
     @ClientCallable
-    private void selectionTreeGridToggleItem(String itemKey, boolean selected, ObjectNode modifierKeys) {
-        T item = getDataCommunicator().getKeyMapper().get(itemKey);
+    private void selectionTreeGridToggleItem(String itemKey, boolean selected, ObjectNode options) {
+        var item = getDataCommunicator().getKeyMapper().get(itemKey);
         if (item == null) {
             throw new IllegalArgumentException("Item with key %s not found".formatted(itemKey));
         }
 
-        boolean ctrlKey = modifierKeys.get("ctrlKey").asBoolean(false);
-        boolean metaKey = modifierKeys.get("metaKey").asBoolean(false);
-        boolean shiftKey = modifierKeys.get("shiftKey").asBoolean(false);
-
-        if (shiftKey) {
-            selectRange(rangeStartItem, item, true);
-            return;
-        }
-
-        if (ctrlKey || metaKey) {
-            if (selected) {
-                select(item);
+        if (selected) {
+            var deselectOthers = options.get("deselectOthers").asBoolean(false);
+            if (deselectOthers) {
+                asMultiSelect().setValue(Set.of(item));
             } else {
-                deselect(item);
+                select(item);
             }
-            return;
+        } else {
+            deselect(item);
         }
 
-        selectRange(item, item, true);
         rangeStartItem = item;
     }
 
+    @ClientCallable
+    private void selectionTreeGridSelectRange(String endItemKey, ObjectNode options) {
+        var rangeEndItem = getDataCommunicator().getKeyMapper().get(endItemKey);
+        if (rangeEndItem == null) {
+            throw new IllegalArgumentException("Item with key %s not found".formatted(endItemKey));
+        }
+
+        var range = fetchItemRange(rangeStartItem, rangeEndItem);
+
+        var deselectOthers = options.get("deselectOthers").asBoolean(false);
+        if (deselectOthers) {
+            asMultiSelect().setValue(new HashSet<>(range));
+        } else {
+            asMultiSelect().select(range);
+        }
+    }
+
+    private List<T> fetchItemRange(T startItem, T endItem) {
+        var items = fetchHierarchyRecursively(null);
+        var startIndex = items.indexOf(startItem);
+        var endIndex = items.indexOf(endItem);
+        return items.subList(
+                Math.min(startIndex, endIndex),
+                Math.max(startIndex, endIndex) + 1);
+    }
+
+    @Override
+    protected void setSelectionModel(GridSelectionModel<T> model, SelectionMode selectionMode) {
+        if (selectionMode == SelectionMode.MULTI) {
+        	setMultiSelectionColumnVisible(multiSelectionColumnVisible);
+        }
+        super.setSelectionModel(model, selectionMode);
+    }
+
     /**
-     * Runs a JavaScript snippet to hide the multi selection / checkbox column on
-     * the client side. The column
+     * Runs a JavaScript snippet to hide the multi selection / checkbox column on the client side. The column
      * is not removed, but set to "hidden" explicitly.
      */
     protected void hideMultiSelectionColumn() {
         this.setMultiSelectionColumnVisible(false);
+    }
+
+    @Override
+    public Column<T> addHierarchyColumn(ValueProvider<T, ?> valueProvider) {
+        Column<T> column = addColumn(LitRenderer.<T> of(
+                "<vaadin-grid-tree-toggle @click=${onClick} .leaf=${!item.children} .expanded=${model.expanded} .level=${model.level}>"
+                        + "</vaadin-grid-tree-toggle>${item.name}")
+                .withProperty("children",
+                        item -> getDataCommunicator().hasChildren(item))
+                .withProperty("name",
+                        value -> String.valueOf(valueProvider.apply(value)))
+                .withFunction("onClick", item -> {
+                    if (getDataCommunicator().hasChildren(item)) {
+                        if (isExpanded(item)) {
+                            collapse(List.of(item), true);
+                        } else {
+                            expand(List.of(item), true);
+                        }
+                    }
+                }));
+        final SerializableComparator<T> comparator =
+                (a, b) -> compareMaybeComparables(valueProvider.apply(a),
+                        valueProvider.apply(b));
+        column.setComparator(comparator);
+
+        return column;
     }
 
     /**
@@ -242,52 +247,49 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
     }
 
     /**
-     * Returns true if the multi selection column is visible, false otherwise.
-     *
-     * @return
-     */
-    public boolean isMultiSelectionColumnVisible() {
-        return multiSelectionColumnVisible;
-    }
+	 * Returns true if the multi selection column is visible, false otherwise.
+	 * @return
+	 */
+	public boolean isMultiSelectionColumnVisible() {
+		return multiSelectionColumnVisible;
+	}
 
-    /**
-     * Sets the visibility of the multi selection column.
-     *
-     * @param multiSelectionColumnVisible - true to show the multi selection column,
-     *                                    false to hide it
-     */
-    public void setMultiSelectionColumnVisible(boolean multiSelectionColumnVisible) {
-        if (this.getSelectionModel() instanceof SelectionModel.Multi) {
-            getElement().getNode().runWhenAttached(ui -> ui.beforeClientResponse(this, context -> {
-                getElement().executeJs(
+	/**
+	 * Sets the visibility of the multi selection column.
+	 *
+	 * @param multiSelectionColumnVisible - true to show the multi selection column, false to hide it
+	 */
+	public void setMultiSelectionColumnVisible(boolean multiSelectionColumnVisible) {
+		if (this.getSelectionModel() instanceof SelectionModel.Multi) {
+	        getElement().getNode().runWhenAttached(ui ->
+            ui.beforeClientResponse(this, context -> {
+            	getElement().executeJs(
                         "if (this.querySelector('vaadin-grid-flow-selection-column')) {" +
-                                " this.querySelector('vaadin-grid-flow-selection-column').hidden = $0 }",
-                        !multiSelectionColumnVisible);
-                this.recalculateColumnWidths();
+                                " this.querySelector('vaadin-grid-flow-selection-column').hidden = $0 }", !multiSelectionColumnVisible);
+            	this.recalculateColumnWidths();
             }));
-        }
-        this.multiSelectionColumnVisible = multiSelectionColumnVisible;
-    }
+		}
+		this.multiSelectionColumnVisible = multiSelectionColumnVisible;
+	}
 
     /**
-     * Returns true if the checkbox selection is persistent, false otherwise.
-     *
-     * @return
-     */
-    public boolean isPersistentCheckboxSelection() {
-        return persistentCheckboxSelection;
-    }
+	 * Returns true if the checkbox selection is persistent, false otherwise.
+	 *
+	 * @return
+	 */
+	public boolean isPersistentCheckboxSelection() {
+		return persistentCheckboxSelection;
+	}
 
-    /**
-     * Sets the checkbox selection to be persistent or not.
-     *
-     * @param persistentCheckboxSelection - true to make the checkbox selection
-     *                                    persistent, false otherwise
-     */
-    public void setPersistentCheckboxSelection(boolean persistentCheckboxSelection) {
-        this.getElement().executeJs("this.classicCheckboxSelection = $0", !persistentCheckboxSelection);
-        this.persistentCheckboxSelection = persistentCheckboxSelection;
-    }
+	/**
+	 * Sets the checkbox selection to be persistent or not.
+	 *
+	 * @param persistentCheckboxSelection - true to make the checkbox selection persistent, false otherwise
+	 */
+	public void setPersistentCheckboxSelection(boolean persistentCheckboxSelection) {
+		this.getElement().executeJs("this.classicCheckboxSelection = $0", !persistentCheckboxSelection);
+		this.persistentCheckboxSelection = persistentCheckboxSelection;
+	}
 
     @SuppressWarnings("unchecked")
     private List<T> fetchHierarchyRecursively(T parent) {

--- a/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
+++ b/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
@@ -74,10 +74,8 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
     /**
      * Creates a new instance using the given hierarchical data provider.
      * <p>
-     * Please note, that when you want to use {@link #focusOnCell} or
-     * {@link #scrollToItem}, the data provider
-     * needs to implement
-     * </p>
+     * Please note, that when you want to use {@link #focusOnCell} or {@link #scrollToItem}, the data provider
+     * needs to implement</p>
      *
      * @param dataProvider dataProvider – the data provider, not null
      * @see TreeGrid#TreeGrid(HierarchicalDataProvider)
@@ -87,8 +85,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
     }
 
     /**
-     * Runs the super.onAttach and hides the multi selection column afterwards (if
-     * necessary).
+     * Runs the super.onAttach and hides the multi selection column afterwards (if necessary).     * necessary).
      *
      * @param attachEvent event
      */
@@ -197,7 +194,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
      * is not removed, but set to "hidden" explicitly.
      */
     protected void hideMultiSelectionColumn() {
-        this.setMultiSelectionColumnVisible(false);
+      this.setMultiSelectionColumnVisible(false);
     }
 
     @Override
@@ -256,7 +253,6 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
 
 	/**
 	 * Sets the visibility of the multi selection column.
-	 *
 	 * @param multiSelectionColumnVisible - true to show the multi selection column, false to hide it
 	 */
 	public void setMultiSelectionColumnVisible(boolean multiSelectionColumnVisible) {

--- a/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
+++ b/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
@@ -113,29 +113,17 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
      * @param column column to focus
      */
     public void focusOnCell(T item, Column<T> column) {
+        int colIndex = (column != null) ? getColumns().indexOf(column) : 0;
+        getElement().callJsFunction("focusOnCellAfterScroll", colIndex);
         scrollToItem(item);
-        // int index = getIndexForItem(item);
-        // if (index >= 0) {
-        // // String internalId = (column != null)?getColumnInternalId(column):"";
-        // int colIndex = (column != null) ? getColumns().indexOf(column) : 0;
-        // this.getElement().executeJs("this.focusOnCellWhenReady($0, $1, true);",
-        // index, colIndex);
-        // }
-    }
-
-    /**
-     * The method for scrolling to an item. Takes into account lazy loading nature
-     * of grid and does the scroll operation only until the grid has finished
-     * loading data
-     *
-     * @param item the item where to scroll to
-     */
-    public void scrollToItem(T item) {
-        super.scrollToItem(item);
     }
 
     @ClientCallable
     private void selectionTreeGridToggleItem(String itemKey, boolean selected, ObjectNode options) {
+        if (getSelectionMode() != SelectionMode.MULTI) {
+            return;
+        }
+
         var item = getDataCommunicator().getKeyMapper().get(itemKey);
         if (item == null) {
             throw new IllegalArgumentException("Item with key %s not found".formatted(itemKey));
@@ -157,6 +145,10 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
 
     @ClientCallable
     private void selectionTreeGridSelectRange(String endItemKey, ObjectNode options) {
+        if (getSelectionMode() != SelectionMode.MULTI) {
+            return;
+        }
+
         var rangeEndItem = getDataCommunicator().getKeyMapper().get(endItemKey);
         if (rangeEndItem == null) {
             throw new IllegalArgumentException("Item with key %s not found".formatted(endItemKey));

--- a/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
+++ b/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
@@ -112,7 +112,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
      * @param column column to focus
      */
     public void focusOnCell(T item, Column<T> column) {
-        expand(getAncestors(item));
+        scrollToItem(item);
         // int index = getIndexForItem(item);
         // if (index >= 0) {
         // // String internalId = (column != null)?getColumnInternalId(column):"";
@@ -130,21 +130,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
      * @param item the item where to scroll to
      */
     public void scrollToItem(T item) {
-        expand(getAncestors(item));
-        // int index = getIndexForItem(item);
-        // if (index >= 0) {
-        // this.getElement().executeJs("this.scrollWhenReady($0, true);", index);
-        // }
-    }
-
-    private List<T> getAncestors(T item) {
-        List<T> ancestors = new ArrayList<>();
-        T parent = getDataProvider().getParent(item);
-        while (parent != null) {
-            ancestors.add(parent);
-            parent = getDataProvider().getParent(parent);
-        }
-        return ancestors;
+        super.scrollToItem(item);
     }
 
     private void selectRange(T startItem, T endItem, boolean deselectOthers) {
@@ -170,7 +156,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
         initSelectionModel();
     }
 
-    public void initSelectionModel() {
+    private void initSelectionModel() {
         if (getSelectionModel() instanceof GridMultiSelectionModel<T>) {
             setMultiSelectionColumnVisible(multiSelectionColumnVisible);
 
@@ -180,10 +166,18 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
                             const selectionColumn = this.querySelector('vaadin-grid-flow-selection-column');
                             selectionColumn.autoSelect = true;
                             selectionColumn._selectItem = function (item) {
-                                grid.$server.selectionTreeGridToggleItem(grid.getItemId(item), true, this._activeModifierKeys);
+                                grid.$server.selectionTreeGridToggleItem(
+                                    grid.getItemId(item),
+                                    true,
+                                    this._activeModifierKeys
+                                );
                             }
                             selectionColumn._deselectItem = function(item) {
-                                grid.$server.selectionTreeGridToggleItem(grid.getItemId(item), false, this._activeModifierKeys);
+                                grid.$server.selectionTreeGridToggleItem(
+                                    grid.getItemId(item),
+                                    false,
+                                    this._activeModifierKeys
+                                );
                             }
                             """);
         }

--- a/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
+++ b/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
@@ -21,6 +21,7 @@ package com.vaadin.componentfactory.selectiongrid;
  */
 
 import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -30,6 +31,9 @@ import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider.HierarchyFormat;
 import com.vaadin.flow.data.selection.SelectionModel;
+
+import tools.jackson.databind.node.ObjectNode;
+
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -89,9 +93,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
-        if (this.getSelectionModel() instanceof SelectionModel.Multi) {
-            setMultiSelectionColumnVisible(multiSelectionColumnVisible);
-        }
+        initSelectionModel();
     }
 
     /**
@@ -113,9 +115,10 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
         expand(getAncestors(item));
         // int index = getIndexForItem(item);
         // if (index >= 0) {
-        //     // String internalId = (column != null)?getColumnInternalId(column):"";
-        //     int colIndex = (column != null) ? getColumns().indexOf(column) : 0;
-        //     this.getElement().executeJs("this.focusOnCellWhenReady($0, $1, true);", index, colIndex);
+        // // String internalId = (column != null)?getColumnInternalId(column):"";
+        // int colIndex = (column != null) ? getColumns().indexOf(column) : 0;
+        // this.getElement().executeJs("this.focusOnCellWhenReady($0, $1, true);",
+        // index, colIndex);
         // }
     }
 
@@ -130,7 +133,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
         expand(getAncestors(item));
         // int index = getIndexForItem(item);
         // if (index >= 0) {
-        //     this.getElement().executeJs("this.scrollWhenReady($0, true);", index);
+        // this.getElement().executeJs("this.scrollWhenReady($0, true);", index);
         // }
     }
 
@@ -146,7 +149,9 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
 
     private void selectRange(T startItem, T endItem, boolean deselectOthers) {
         var items = fetchHierarchyRecursively(null);
-        var range = items.subList(items.indexOf(startItem), items.indexOf(endItem) + 1);
+        var startIndex = items.indexOf(startItem);
+        var endIndex = items.indexOf(endItem);
+        var range = items.subList(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1);
 
         if (deselectOthers) {
             var oldSelectedItems = new HashSet<>(getSelectedItems());
@@ -161,27 +166,56 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
 
     @Override
     protected void setSelectionModel(GridSelectionModel<T> model, SelectionMode selectionMode) {
-        if (selectionMode == SelectionMode.MULTI) {
-            setMultiSelectionColumnVisible(multiSelectionColumnVisible);
-        }
-
         super.setSelectionModel(model, selectionMode);
+        initSelectionModel();
+    }
 
-        if (selectionMode == SelectionMode.MULTI) {
-            addMultiSelectionToggleListener();
+    public void initSelectionModel() {
+        if (getSelectionModel() instanceof GridMultiSelectionModel<T>) {
+            setMultiSelectionColumnVisible(multiSelectionColumnVisible);
+
+            getElement().executeJs(
+                    """
+                            const grid = this;
+                            const selectionColumn = this.querySelector('vaadin-grid-flow-selection-column');
+                            selectionColumn.autoSelect = true;
+                            selectionColumn._selectItem = function (item) {
+                                grid.$server.selectionTreeGridToggleItem(grid.getItemId(item), true, this._activeModifierKeys);
+                            }
+                            selectionColumn._deselectItem = function(item) {
+                                grid.$server.selectionTreeGridToggleItem(grid.getItemId(item), false, this._activeModifierKeys);
+                            }
+                            """);
         }
     }
 
-    private void addMultiSelectionToggleListener() {
-        ((GridMultiSelectionModel<T>) getSelectionModel()).addClientItemToggleListener((event) -> {
-            if (event.isShiftKey()) {
-                selectRange(rangeStartItem, event.getItem(), true);
-                return;
-            }
+    @ClientCallable
+    private void selectionTreeGridToggleItem(String itemKey, boolean selected, ObjectNode modifierKeys) {
+        T item = getDataCommunicator().getKeyMapper().get(itemKey);
+        if (item == null) {
+            throw new IllegalArgumentException("Item with key %s not found".formatted(itemKey));
+        }
 
-            rangeStartItem = event.getItem();
-            selectRange(rangeStartItem, rangeStartItem, true);
-        });
+        boolean ctrlKey = modifierKeys.get("ctrlKey").asBoolean(false);
+        boolean metaKey = modifierKeys.get("metaKey").asBoolean(false);
+        boolean shiftKey = modifierKeys.get("shiftKey").asBoolean(false);
+
+        if (shiftKey) {
+            selectRange(rangeStartItem, item, true);
+            return;
+        }
+
+        if (ctrlKey || metaKey) {
+            if (selected) {
+                select(item);
+            } else {
+                deselect(item);
+            }
+            return;
+        }
+
+        selectRange(item, item, true);
+        rangeStartItem = item;
     }
 
     /**

--- a/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
+++ b/selection-grid-flow/src/main/java/com/vaadin/componentfactory/selectiongrid/SelectionTreeGrid.java
@@ -21,24 +21,15 @@ package com.vaadin.componentfactory.selectiongrid;
  */
 
 import com.vaadin.flow.component.AttachEvent;
-import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.grid.GridMultiSelectionModel;
 import com.vaadin.flow.component.grid.GridSelectionModel;
 import com.vaadin.flow.component.treegrid.TreeGrid;
-import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataCommunicator;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider;
-import com.vaadin.flow.data.provider.hierarchy.HierarchyMapper;
-import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
-import com.vaadin.flow.data.renderer.LitRenderer;
+import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider.HierarchyFormat;
 import com.vaadin.flow.data.selection.SelectionModel;
-import com.vaadin.flow.function.SerializableComparator;
-import com.vaadin.flow.function.ValueProvider;
-import com.vaadin.flow.internal.Range;
-
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -56,6 +47,8 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
 
     private boolean multiSelectionColumnVisible = false;
     private boolean persistentCheckboxSelection = true;
+
+    private T rangeStartItem;
 
     /**
      * @see TreeGrid#TreeGrid()
@@ -75,8 +68,10 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
     /**
      * Creates a new instance using the given hierarchical data provider.
      * <p>
-     * Please note, that when you want to use {@link #focusOnCell} or {@link #scrollToItem}, the data provider
-     * needs to implement</p>
+     * Please note, that when you want to use {@link #focusOnCell} or
+     * {@link #scrollToItem}, the data provider
+     * needs to implement
+     * </p>
      *
      * @param dataProvider dataProvider – the data provider, not null
      * @see TreeGrid#TreeGrid(HierarchicalDataProvider)
@@ -86,7 +81,8 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
     }
 
     /**
-     * Runs the super.onAttach and hides the multi selection column afterwards (if necessary).
+     * Runs the super.onAttach and hides the multi selection column afterwards (if
+     * necessary).
      *
      * @param attachEvent event
      */
@@ -94,7 +90,7 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         if (this.getSelectionModel() instanceof SelectionModel.Multi) {
-        	setMultiSelectionColumnVisible(multiSelectionColumnVisible);
+            setMultiSelectionColumnVisible(multiSelectionColumnVisible);
         }
     }
 
@@ -114,13 +110,13 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
      * @param column column to focus
      */
     public void focusOnCell(T item, Column<T> column) {
-        expandAncestor(item);
-        int index = getIndexForItem(item);
-        if (index >= 0) {
-            //String internalId = (column != null)?getColumnInternalId(column):"";
-            int colIndex = (column != null) ? getColumns().indexOf(column) : 0;
-            this.getElement().executeJs("this.focusOnCellWhenReady($0, $1, true);", index, colIndex);
-        }
+        expand(getAncestors(item));
+        // int index = getIndexForItem(item);
+        // if (index >= 0) {
+        //     // String internalId = (column != null)?getColumnInternalId(column):"";
+        //     int colIndex = (column != null) ? getColumns().indexOf(column) : 0;
+        //     this.getElement().executeJs("this.focusOnCellWhenReady($0, $1, true);", index, colIndex);
+        // }
     }
 
     /**
@@ -131,137 +127,70 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
      * @param item the item where to scroll to
      */
     public void scrollToItem(T item) {
-        expandAncestor(item);
-        int index = getIndexForItem(item);
-        if (index >= 0) {
-            this.getElement().executeJs("this.scrollWhenReady($0, true);", index);
-        }
+        expand(getAncestors(item));
+        // int index = getIndexForItem(item);
+        // if (index >= 0) {
+        //     this.getElement().executeJs("this.scrollWhenReady($0, true);", index);
+        // }
     }
 
-    private List<T> expandAncestor(T item) {
+    private List<T> getAncestors(T item) {
         List<T> ancestors = new ArrayList<>();
-
-        ParentItemProvider<T> parentItemProvider = getParentItemProvider();
-
-        Optional<T> parent = parentItemProvider.getParent(item);
-        while (parent.isPresent()) {
-            ancestors.add(parent.get());
-            parent = parentItemProvider.getParent(parent.get());
-        }
-        if (!ancestors.isEmpty()) {
-            expand(ancestors);
+        T parent = getDataProvider().getParent(item);
+        while (parent != null) {
+            ancestors.add(parent);
+            parent = getDataProvider().getParent(parent);
         }
         return ancestors;
     }
 
-    @SuppressWarnings("unchecked")
-    private ParentItemProvider<T> getParentItemProvider() {
-        ParentItemProvider<T> parentItemProvider;
-        if (getDataProvider() instanceof TreeDataProvider) {
-            return itemToCheck -> Optional.ofNullable(getTreeData().getParent(itemToCheck));
+    private void selectRange(T startItem, T endItem, boolean deselectOthers) {
+        var items = fetchHierarchyRecursively(null);
+        var range = items.subList(items.indexOf(startItem), items.indexOf(endItem) + 1);
+
+        if (deselectOthers) {
+            var oldSelectedItems = new HashSet<>(getSelectedItems());
+            var newSelectedItems = new HashSet<>(range);
+            oldSelectedItems.removeAll(newSelectedItems);
+            asMultiSelect().updateSelection(newSelectedItems, oldSelectedItems);
+            return;
         }
 
-        if (getDataProvider() instanceof ParentItemProvider) {
-            return (ParentItemProvider<T>) getDataProvider();
-        }
-
-        throw new IllegalStateException("The data provider must either be a TreeDataProvider or " +
-                "implement ParentItemProvider to use this method");
-    }
-
-    private int getIndexForItem(T item) {
-        HierarchicalDataCommunicator<T> dataCommunicator = super.getDataCommunicator();
-        return dataCommunicator.getIndex(item);
-    }
-  
-    @ClientCallable
-    private void selectRange(int fromIndex, int toIndex) {
-        int from = Math.min(fromIndex, toIndex);
-        int to = Math.max(fromIndex, toIndex);
-
-        HierarchicalDataCommunicator<T> dataCommunicator = super.getDataCommunicator();
-        Method getHierarchyMapper;
-        try {
-            getHierarchyMapper = HierarchicalDataCommunicator.class.getDeclaredMethod("getHierarchyMapper");
-            getHierarchyMapper.setAccessible(true);
-            HierarchyMapper<T, ?> mapper = (HierarchyMapper<T, ?>) getHierarchyMapper.invoke(dataCommunicator);
-            asMultiSelect().select((mapper.fetchHierarchyItems(Range.withLength(from, to - from + 1))).collect(Collectors.toSet()));
-        } catch (Exception ignored) {
-        }
-    }
-
-    /**
-     * Select the range and deselect the other items
-     *
-     * @param fromIndex
-     * @param toIndex
-     */
-    @ClientCallable
-    private void selectRangeOnly(int fromIndex, int toIndex) {
-        GridSelectionModel<T> model = getSelectionModel();
-        if (model instanceof GridMultiSelectionModel) {
-            int from = Math.min(fromIndex, toIndex);
-            int to = Math.max(fromIndex, toIndex);
-            HierarchicalDataCommunicator<T> dataCommunicator = super.getDataCommunicator();
-            Method getHierarchyMapper;
-            try {
-                getHierarchyMapper = HierarchicalDataCommunicator.class.getDeclaredMethod("getHierarchyMapper");
-                getHierarchyMapper.setAccessible(true);
-                HierarchyMapper<T, ?> mapper = (HierarchyMapper<T, ?>) getHierarchyMapper.invoke(dataCommunicator);
-                Set<T> newSelectedItems = (mapper.fetchHierarchyItems(Range.withLength(from, to - from + 1))).collect(Collectors.toSet());
-                HashSet<T> oldSelectedItems = new HashSet<>(getSelectedItems());
-                oldSelectedItems.removeAll(newSelectedItems);
-                asMultiSelect().updateSelection(newSelectedItems, oldSelectedItems);
-            } catch (Exception ignored) {
-            }
-        }
-    }
-    
-    @ClientCallable
-    private void selectRangeOnlyOnClick(int fromIndex, int toIndex) {
-        selectRangeOnly(fromIndex, toIndex);
+        asMultiSelect().select(range);
     }
 
     @Override
     protected void setSelectionModel(GridSelectionModel<T> model, SelectionMode selectionMode) {
         if (selectionMode == SelectionMode.MULTI) {
-        	setMultiSelectionColumnVisible(multiSelectionColumnVisible);
+            setMultiSelectionColumnVisible(multiSelectionColumnVisible);
         }
+
         super.setSelectionModel(model, selectionMode);
+
+        if (selectionMode == SelectionMode.MULTI) {
+            addMultiSelectionToggleListener();
+        }
+    }
+
+    private void addMultiSelectionToggleListener() {
+        ((GridMultiSelectionModel<T>) getSelectionModel()).addClientItemToggleListener((event) -> {
+            if (event.isShiftKey()) {
+                selectRange(rangeStartItem, event.getItem(), true);
+                return;
+            }
+
+            rangeStartItem = event.getItem();
+            selectRange(rangeStartItem, rangeStartItem, true);
+        });
     }
 
     /**
-     * Runs a JavaScript snippet to hide the multi selection / checkbox column on the client side. The column
+     * Runs a JavaScript snippet to hide the multi selection / checkbox column on
+     * the client side. The column
      * is not removed, but set to "hidden" explicitly.
      */
     protected void hideMultiSelectionColumn() {
-    	this.setMultiSelectionColumnVisible(false);
-    }
-
-    @Override
-    public Column<T> addHierarchyColumn(ValueProvider<T, ?> valueProvider) {
-        Column<T> column = addColumn(LitRenderer.<T> of(
-                "<vaadin-grid-tree-toggle @click=${onClick} .leaf=${!item.children} .expanded=${model.expanded} .level=${model.level}>"
-                        + "</vaadin-grid-tree-toggle>${item.name}")
-                .withProperty("children",
-                        item -> getDataCommunicator().hasChildren(item))
-                .withProperty("name",
-                        value -> String.valueOf(valueProvider.apply(value)))
-                .withFunction("onClick", item -> {
-                    if (getDataCommunicator().hasChildren(item)) {
-                        if (isExpanded(item)) {
-                            collapse(List.of(item), true);
-                        } else {
-                            expand(List.of(item), true);
-                        }
-                    }
-                }));
-        final SerializableComparator<T> comparator =
-                (a, b) -> compareMaybeComparables(valueProvider.apply(a),
-                        valueProvider.apply(b));
-        column.setComparator(comparator);
-
-        return column;
+        this.setMultiSelectionColumnVisible(false);
     }
 
     /**
@@ -284,48 +213,69 @@ public class SelectionTreeGrid<T> extends TreeGrid<T> {
                 .map(SelectionGridVariant::getVariantName).collect(Collectors.toList()));
     }
 
-	/**
-	 * Returns true if the multi selection column is visible, false otherwise.
-	 * @return
-	 */
-	public boolean isMultiSelectionColumnVisible() {
-		return multiSelectionColumnVisible;
-	}
+    /**
+     * Returns true if the multi selection column is visible, false otherwise.
+     *
+     * @return
+     */
+    public boolean isMultiSelectionColumnVisible() {
+        return multiSelectionColumnVisible;
+    }
 
-	/**
-	 * Sets the visibility of the multi selection column.
-	 * 
-	 * @param multiSelectionColumnVisible - true to show the multi selection column, false to hide it
-	 */
-	public void setMultiSelectionColumnVisible(boolean multiSelectionColumnVisible) {
-		if (this.getSelectionModel() instanceof SelectionModel.Multi) {
-	        getElement().getNode().runWhenAttached(ui ->
-            ui.beforeClientResponse(this, context -> {
-            	getElement().executeJs(
+    /**
+     * Sets the visibility of the multi selection column.
+     *
+     * @param multiSelectionColumnVisible - true to show the multi selection column,
+     *                                    false to hide it
+     */
+    public void setMultiSelectionColumnVisible(boolean multiSelectionColumnVisible) {
+        if (this.getSelectionModel() instanceof SelectionModel.Multi) {
+            getElement().getNode().runWhenAttached(ui -> ui.beforeClientResponse(this, context -> {
+                getElement().executeJs(
                         "if (this.querySelector('vaadin-grid-flow-selection-column')) {" +
-                                " this.querySelector('vaadin-grid-flow-selection-column').hidden = $0 }", !multiSelectionColumnVisible);
-            	this.recalculateColumnWidths();
+                                " this.querySelector('vaadin-grid-flow-selection-column').hidden = $0 }",
+                        !multiSelectionColumnVisible);
+                this.recalculateColumnWidths();
             }));
-		}
-		this.multiSelectionColumnVisible = multiSelectionColumnVisible;
-	}
+        }
+        this.multiSelectionColumnVisible = multiSelectionColumnVisible;
+    }
 
-	/**
-	 * Returns true if the checkbox selection is persistent, false otherwise.
-	 * 
-	 * @return
-	 */
-	public boolean isPersistentCheckboxSelection() {
-		return persistentCheckboxSelection;
-	}
+    /**
+     * Returns true if the checkbox selection is persistent, false otherwise.
+     *
+     * @return
+     */
+    public boolean isPersistentCheckboxSelection() {
+        return persistentCheckboxSelection;
+    }
 
-	/**
-	 * Sets the checkbox selection to be persistent or not.
-	 * 
-	 * @param persistentCheckboxSelection - true to make the checkbox selection persistent, false otherwise
-	 */
-	public void setPersistentCheckboxSelection(boolean persistentCheckboxSelection) {
-		this.getElement().executeJs("this.classicCheckboxSelection = $0", !persistentCheckboxSelection);
-		this.persistentCheckboxSelection = persistentCheckboxSelection;
-	}
+    /**
+     * Sets the checkbox selection to be persistent or not.
+     *
+     * @param persistentCheckboxSelection - true to make the checkbox selection
+     *                                    persistent, false otherwise
+     */
+    public void setPersistentCheckboxSelection(boolean persistentCheckboxSelection) {
+        this.getElement().executeJs("this.classicCheckboxSelection = $0", !persistentCheckboxSelection);
+        this.persistentCheckboxSelection = persistentCheckboxSelection;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<T> fetchHierarchyRecursively(T parent) {
+        var dataCommunicator = getDataCommunicator();
+        var dataProvider = (HierarchicalDataProvider<T, Object>) dataCommunicator.getDataProvider();
+        var query = dataCommunicator.buildQuery(parent, 0, Integer.MAX_VALUE);
+
+        var result = new ArrayList<T>();
+        dataProvider.fetchChildren(query).forEach((child) -> {
+            result.add(child);
+
+            if (dataProvider.getHierarchyFormat().equals(HierarchyFormat.NESTED)
+                    && dataCommunicator.isExpanded(child)) {
+                result.addAll(fetchHierarchyRecursively(child));
+            }
+        });
+        return result;
+    }
 }

--- a/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/helpers.js
+++ b/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/helpers.js
@@ -70,6 +70,17 @@ export function _selectionGridSelectRowWithItem(e, item, index) {
     }
     // if ctrl click
     if (e.shiftKey && this.rangeSelectRowFrom >= 0) {
+        if((this.rangeSelectRowFrom - index) !== 0) { // clear text selection, if multiple rows are selected using shift
+            const sel = window.getSelection ? window.getSelection() : document.selection;
+            if (sel) {
+                if (sel.removeAllRanges) {
+                    sel.removeAllRanges();
+                } else if (sel.empty) {
+                    sel.empty();
+                }
+            }
+        }
+
         if (!ctrlKey) {
           if (this.$server?.selectionTreeGridSelectRange) {
             this.$server.selectionTreeGridSelectRange(item.key, { deselectOthers: true });

--- a/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/helpers.js
+++ b/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/helpers.js
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -56,11 +56,13 @@ export function _selectionGridSelectRowWithItem(e, item, index) {
     }
     // if click select only this row
     if (!ctrlKey && !e.shiftKey) {
-        if (this.$server) {
-			this._debounce(() => { 
+      if (this.$server?.selectionTreeGridToggleItem) {
+        this.$server.selectionTreeGridToggleItem(item.key, true, { deselectOthers: true });
+      } else if (this.$server) {
+			this._debounce(() => {
 				this.$server.selectRangeOnlyOnClick(index, index);
             }, 100);
-            
+
         } else {
             this.selectedItems = [];
             this.selectItem(item);
@@ -68,47 +70,46 @@ export function _selectionGridSelectRowWithItem(e, item, index) {
     }
     // if ctrl click
     if (e.shiftKey && this.rangeSelectRowFrom >= 0) {
-        if((this.rangeSelectRowFrom - index) !== 0) { // clear text selection, if multiple rows are selected using shift
-            const sel = window.getSelection ? window.getSelection() : document.selection;
-            if (sel) {
-                if (sel.removeAllRanges) {
-                    sel.removeAllRanges();
-                } else if (sel.empty) {
-                    sel.empty();
-                }
-            }
-        }
-
         if (!ctrlKey) {
-            if (this.$server) {
-				this._debounce(() => { 
+          if (this.$server?.selectionTreeGridSelectRange) {
+            this.$server.selectionTreeGridSelectRange(item.key, { deselectOthers: true });
+          } else if (this.$server) {
+				this._debounce(() => {
                 	this.$server.selectRangeOnly(this.rangeSelectRowFrom, index);
             	}, 100);
             }
         } else {
-            if (this.$server) {
-				this._debounce(() => { 
+            if (this.$server?.selectionTreeGridSelectRange) {
+            this.$server.selectionTreeGridSelectRange(item.key, { deselectOthers: false });
+          } else if (this.$server) {
+				this._debounce(() => {
                 	this.$server.selectRange(this.rangeSelectRowFrom, index);
                 }, 100);
             }
         }
     } else {
         if (!ctrlKey) {
-            if (this.$server) {
-				this._debounce(() => { 
+          if (this.$server?.selectionTreeGridToggleItem) {
+            this.$server.selectionTreeGridToggleItem(item.key, true, { deselectOthers: true });
+          } else if (this.$server) {
+				this._debounce(() => {
 					this.$server.selectRangeOnlyOnClick(index, index);
 	            }, 100);
             }
         } else {
             if (this.selectedItems && this.selectedItems.some((i) => i.key === item.key)) {
-                if (this.$connector) {
+                if (this.$server?.selectionTreeGridToggleItem) {
+                  this.$server.selectionTreeGridToggleItem(item.key, false, { deselectOthers: false });
+                } else if (this.$connector) {
                     this.$connector.doDeselection([item], true);
                 } else {
                     this.deselectItem(item);
                 }
             } else {
-                if (this.$server) {
-					this._debounce(() => { 
+                if (this.$server?.selectionTreeGridToggleItem) {
+                  this.$server.selectionTreeGridToggleItem(item.key, true, { deselectOthers: false });
+                } else if (this.$server) {
+					this._debounce(() => {
                     	this.$server.selectRange(index, index);
                     }, 100);
                 }

--- a/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/helpers.js
+++ b/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/helpers.js
@@ -129,34 +129,3 @@ export function _selectionGridSelectRowWithItem(e, item, index) {
         this.rangeSelectRowFrom = index;
     }
 }
-
-export function _getItemOverriden(idx, el) {
-    if (idx >= this._flatSize) {
-        return;
-    }
-    el.index = idx;
-    const { cache, index } = this._dataProviderController.getFlatIndexContext(idx);
-    const item = cache.items[index];
-    if (item) {
-        this.__updateLoading(el, false);
-        this._updateItem(el, item);
-        if (this._isExpanded(item)) {
-            this._dataProviderController.ensureFlatIndexHierarchy(idx);
-        }
-    } else {
-        this.__updateLoading(el, true);
-        const page = Math.floor(index / this.pageSize);
-        this._dataProviderController.__loadCachePage(cache, page);
-    }
-    /** focus when get item if there is an item to focus **/
-    if (this._rowNumberToFocus > -1) {
-        if (idx === this._rowNumberToFocus) {
-            const row = Array.from(this.$.items.children).filter(
-                (child) => child.index === this._rowNumberToFocus
-            )[0];
-            if (row) {
-                this._focus();
-            }
-        }
-    }
-}

--- a/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/selection-grid.js
+++ b/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/selection-grid.js
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,52 +20,52 @@
 customElements.whenDefined("vaadin-selection-grid").then(() => {
     const Grid = customElements.get("vaadin-selection-grid");
     if (Grid) {
-        const oldClickHandler = Grid.prototype._onClick;
-        Grid.prototype._onClick = function _click(e) {
-            const boundOldClickHandler = oldClickHandler.bind(this);
-            boundOldClickHandler(e);
+        // const oldClickHandler = Grid.prototype._onClick;
+        // Grid.prototype._onClick = function _click(e) {
+        //     const boundOldClickHandler = oldClickHandler.bind(this);
+        //     boundOldClickHandler(e);
 
-            this._selectionGridSelectRow(e);
-        };
-        Grid.prototype.old_onNavigationKeyDown = Grid.prototype._onNavigationKeyDown;
-        Grid.prototype._onNavigationKeyDown = function _onNavigationKeyDownOverridden(e, key) {
-            this.old_onNavigationKeyDown(e,key);
-            const ctrlKey = (e.metaKey)?e.metaKey:e.ctrlKey;
-            if (e.shiftKey || !ctrlKey) {
-                // select on shift down on shift up
-                if (key === 'ArrowDown' || key === 'ArrowUp') {
-                    const row = Array.from(this.$.items.children).filter(
-                        (child) => child.index === this._focusedItemIndex
-                    )[0];
-                    if (row && typeof row.index != 'undefined') {
-                        this._selectionGridSelectRowWithItem(e, row._item, row.index);
-                    }
-                }
-            } // else do nothing
-        }
+        //     this._selectionGridSelectRow(e);
+        // };
+        // Grid.prototype.old_onNavigationKeyDown = Grid.prototype._onNavigationKeyDown;
+        // Grid.prototype._onNavigationKeyDown = function _onNavigationKeyDownOverridden(e, key) {
+        //     this.old_onNavigationKeyDown(e,key);
+        //     const ctrlKey = (e.metaKey)?e.metaKey:e.ctrlKey;
+        //     if (e.shiftKey || !ctrlKey) {
+        //         // select on shift down on shift up
+        //         if (key === 'ArrowDown' || key === 'ArrowUp') {
+        //             const row = Array.from(this.$.items.children).filter(
+        //                 (child) => child.index === this._focusedItemIndex
+        //             )[0];
+        //             if (row && typeof row.index != 'undefined') {
+        //                 this._selectionGridSelectRowWithItem(e, row._item, row.index);
+        //             }
+        //         }
+        //     } // else do nothing
+        // }
 
-        Grid.prototype.old_onSpaceKeyDown = Grid.prototype._onSpaceKeyDown;
-        Grid.prototype._onSpaceKeyDown = function _onSpaceKeyDownOverriden(e) {
-            this.old_onSpaceKeyDown(e);
-            const tr = e.composedPath().find((p) => p.nodeName === "TR");
-            if (tr && typeof tr.index != 'undefined') {
-                const item = tr._item;
-                const index = tr.index;
-                if (this.selectedItems && this.selectedItems.some((i) => i.key === item.key)) {
-                    if (this.$connector) {
-                        this.$connector.doDeselection([item], true);
-                    } else {
-                        this.deselectItem(item);
-                    }
-                } else {
-                    if (this.$server) {
-                        this.$server.selectRangeOnly(index, index);
-                    } else {
-                        this.selectedItems = [];
-                        this.selectItem(item);
-                    }
-                }
-            }
-        }
+        // Grid.prototype.old_onSpaceKeyDown = Grid.prototype._onSpaceKeyDown;
+        // Grid.prototype._onSpaceKeyDown = function _onSpaceKeyDownOverriden(e) {
+        //     this.old_onSpaceKeyDown(e);
+        //     const tr = e.composedPath().find((p) => p.nodeName === "TR");
+        //     if (tr && typeof tr.index != 'undefined') {
+        //         const item = tr._item;
+        //         const index = tr.index;
+        //         if (this.selectedItems && this.selectedItems.some((i) => i.key === item.key)) {
+        //             if (this.$connector) {
+        //                 this.$connector.doDeselection([item], true);
+        //             } else {
+        //                 this.deselectItem(item);
+        //             }
+        //         } else {
+        //             if (this.$server) {
+        //                 this.$server.selectRangeOnly(index, index);
+        //             } else {
+        //                 this.selectedItems = [];
+        //                 this.selectItem(item);
+        //             }
+        //         }
+        //     }
+        // }
     }
 });

--- a/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/selection-grid.js
+++ b/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/selection-grid.js
@@ -20,52 +20,56 @@
 customElements.whenDefined("vaadin-selection-grid").then(() => {
     const Grid = customElements.get("vaadin-selection-grid");
     if (Grid) {
-        // const oldClickHandler = Grid.prototype._onClick;
-        // Grid.prototype._onClick = function _click(e) {
-        //     const boundOldClickHandler = oldClickHandler.bind(this);
-        //     boundOldClickHandler(e);
+        const oldClickHandler = Grid.prototype._onClick;
+        Grid.prototype._onClick = function _click(e) {
+            const boundOldClickHandler = oldClickHandler.bind(this);
+            boundOldClickHandler(e);
 
-        //     this._selectionGridSelectRow(e);
-        // };
-        // Grid.prototype.old_onNavigationKeyDown = Grid.prototype._onNavigationKeyDown;
-        // Grid.prototype._onNavigationKeyDown = function _onNavigationKeyDownOverridden(e, key) {
-        //     this.old_onNavigationKeyDown(e,key);
-        //     const ctrlKey = (e.metaKey)?e.metaKey:e.ctrlKey;
-        //     if (e.shiftKey || !ctrlKey) {
-        //         // select on shift down on shift up
-        //         if (key === 'ArrowDown' || key === 'ArrowUp') {
-        //             const row = Array.from(this.$.items.children).filter(
-        //                 (child) => child.index === this._focusedItemIndex
-        //             )[0];
-        //             if (row && typeof row.index != 'undefined') {
-        //                 this._selectionGridSelectRowWithItem(e, row._item, row.index);
-        //             }
-        //         }
-        //     } // else do nothing
-        // }
+            this._selectionGridSelectRow(e);
+        };
+        Grid.prototype.old_onNavigationKeyDown = Grid.prototype._onNavigationKeyDown;
+        Grid.prototype._onNavigationKeyDown = function _onNavigationKeyDownOverridden(e, key) {
+            this.old_onNavigationKeyDown(e,key);
+            const ctrlKey = (e.metaKey)?e.metaKey:e.ctrlKey;
+            if (e.shiftKey || !ctrlKey) {
+                // select on shift down on shift up
+                if (key === 'ArrowDown' || key === 'ArrowUp') {
+                    const row = Array.from(this.$.items.children).filter(
+                        (child) => child.index === this._focusedItemIndex
+                    )[0];
+                    if (row && typeof row.index != 'undefined') {
+                        this._selectionGridSelectRowWithItem(e, row._item, row.index);
+                    }
+                }
+            } // else do nothing
+        }
 
-        // Grid.prototype.old_onSpaceKeyDown = Grid.prototype._onSpaceKeyDown;
-        // Grid.prototype._onSpaceKeyDown = function _onSpaceKeyDownOverriden(e) {
-        //     this.old_onSpaceKeyDown(e);
-        //     const tr = e.composedPath().find((p) => p.nodeName === "TR");
-        //     if (tr && typeof tr.index != 'undefined') {
-        //         const item = tr._item;
-        //         const index = tr.index;
-        //         if (this.selectedItems && this.selectedItems.some((i) => i.key === item.key)) {
-        //             if (this.$connector) {
-        //                 this.$connector.doDeselection([item], true);
-        //             } else {
-        //                 this.deselectItem(item);
-        //             }
-        //         } else {
-        //             if (this.$server) {
-        //                 this.$server.selectRangeOnly(index, index);
-        //             } else {
-        //                 this.selectedItems = [];
-        //                 this.selectItem(item);
-        //             }
-        //         }
-        //     }
-        // }
+        Grid.prototype.old_onSpaceKeyDown = Grid.prototype._onSpaceKeyDown;
+        Grid.prototype._onSpaceKeyDown = function _onSpaceKeyDownOverriden(e) {
+            this.old_onSpaceKeyDown(e);
+            const tr = e.composedPath().find((p) => p.nodeName === "TR");
+            if (tr && typeof tr.index != 'undefined') {
+                const item = tr._item;
+                const index = tr.index;
+                if (this.selectedItems && this.selectedItems.some((i) => i.key === item.key)) {
+                    if (this.$server?.selectionTreeGridToggleItem) {
+                        this.$server.selectionTreeGridToggleItem(item.key, false, { deselectOthers: false });
+                    } else if (this.$connector) {
+                        this.$connector.doDeselection([item], true);
+                    } else {
+                        this.deselectItem(item);
+                    }
+                } else {
+                    if (this.$server?.selectionTreeGridToggleItem) {
+                      this.$server.selectionTreeGridToggleItem(item.key, true, { deselectOthers: false });
+                    } else if (this.$server) {
+                        this.$server.selectRangeOnly(item, item);
+                    } else {
+                        this.selectedItems = [];
+                        this.selectItem(item);
+                    }
+                }
+            }
+        }
     }
 });

--- a/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/vcf-selection-grid.js
+++ b/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/vcf-selection-grid.js
@@ -80,7 +80,7 @@ class VcfSelectionGridElement extends ElementMixin(ThemableMixin(GridElement)) {
     }
 
     static get version() {
-        return '0.2.0';
+        return '4.0.0';
     }
 
     static get lumoInjector() {

--- a/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/vcf-selection-grid.js
+++ b/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/vcf-selection-grid.js
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,9 +25,9 @@ import { Grid as GridElement } from  '@vaadin/grid/src/vaadin-grid.js';
 import {
     _getItemOverriden,
     _selectionGridSelectRow,
-    _selectionGridSelectRowWithItem,    
+    _selectionGridSelectRowWithItem,
     _debounce
-    
+
 } from './helpers';
 
 class VcfSelectionGridElement extends ElementMixin(ThemableMixin(GridElement)) {
@@ -149,6 +149,10 @@ class VcfSelectionGridElement extends ElementMixin(ThemableMixin(GridElement)) {
 
     static get version() {
         return '0.2.0';
+    }
+
+    static get lumoInjector() {
+      return { ...super.lumoInjector, is: 'vaadin-grid' }
     }
 }
 

--- a/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/vcf-selection-grid.js
+++ b/selection-grid-flow/src/main/resources/META-INF/resources/frontend/src/vcf-selection-grid.js
@@ -23,7 +23,6 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin';
 import { Grid as GridElement } from  '@vaadin/grid/src/vaadin-grid.js';
 
 import {
-    _getItemOverriden,
     _selectionGridSelectRow,
     _selectionGridSelectRowWithItem,
     _debounce
@@ -34,7 +33,6 @@ class VcfSelectionGridElement extends ElementMixin(ThemableMixin(GridElement)) {
 
     constructor() {
         super();
-        this._getItemOverriden = _getItemOverriden.bind(this);
         this._selectionGridSelectRow = _selectionGridSelectRow.bind(this);
         this._selectionGridSelectRowWithItem = _selectionGridSelectRowWithItem.bind(this);
         this._debounce = _debounce.bind(this);
@@ -49,98 +47,32 @@ class VcfSelectionGridElement extends ElementMixin(ThemableMixin(GridElement)) {
         };
     }
 
-    ready() {
-        super.ready();
-        this._getItem = this._getItemOverriden;
+    /** @override */
+    _scrollToFlatIndex(rowIndex) {
+      super._scrollToFlatIndex(rowIndex);
+
+      const cellIndex = this.__focusOnCellAfterScroll;
+      if (typeof cellIndex === 'number') {
+        this.focusOnCell(rowIndex, cellIndex);
+      }
+      this.__focusOnCellAfterScroll = null;
     }
 
-    connectedCallback() {
-        super.connectedCallback();
-
-    }
-
-    focusOnCell(rowNumber, cellNumber, nbOfCalls = 1) {
-        if (nbOfCalls < 11) { // dont make an infinite loop
-            if (rowNumber < 0 || cellNumber < 0) {
-                throw "index out of bound";
-            }
-            this.scrollToIndex(rowNumber);
-            /** workaround when the expanded node opens children the index is outside the grid size
-             * https://github.com/vaadin/vaadin-grid/issues/2060
-             * Remove this once this is fixed
-             **/
-            if (rowNumber > this._effectiveSize) {
-                const that = this;
-                setTimeout(() => {
-                    that.focusOnCell(rowNumber, cellNumber, nbOfCalls + 1);
-                }, 200);
-            } else {
-                this._startToFocus(rowNumber, cellNumber);
-            }
-            /** End of workaround **/
-        }
-    };
-
-    _startToFocus(rowNumber, cellNumber) {
-        this._rowNumberToFocus = rowNumber;
-        this._cellNumberToFocus = cellNumber;
-        const row = Array.from(this.$.items.children).filter(
-            (child) => child.index === rowNumber
-        )[0];
-        // if row is already
-        if (row) {
-            const cell = row.children[cellNumber];
-            if (cell) {
-                cell.focus();
-            } else {
-                throw "index out of bound";
-            }
-        }
-    };
-
-    _focus() {
-        const rowNumber = this._rowNumberToFocus;
-        const cellNumber = this._cellNumberToFocus;
-        this._rowNumberToFocus = -1;
-        this._cellNumberToFocus = -1;
-        const row = Array.from(this.$.items.children).filter(
-            (child) => child.index === rowNumber
-        )[0];
-        const cell = row.children[cellNumber];
+    focusOnCell(rowIndex, cellIndex) {
+      const row = [...this.$.items.children].find((row) => row.index === rowIndex);
+      if (row) {
+        const cell = row.children[cellIndex];
         if (cell) {
-            cell.focus();
+          cell.focus();
         } else {
-            throw "index out of bound";
+          throw "index out of bound";
         }
-        this._rowNumberToFocus = -1;
-        this._cellNumberToFocus = -1;
-    };
+      }
+    }
 
-    focusOnCellWhenReady(rowIndex, colId, firstCall) {
-        if (this.loading || firstCall) {
-            var that = this;
-            setTimeout(function () {
-                that.focusOnCellWhenReady(rowIndex, colId, false);
-            }, 1);
-        } else {
-            this.focusOnCell(rowIndex, colId);
-        }
+    focusOnCellAfterScroll(cellIndex) {
+      this.__focusOnCellAfterScroll = cellIndex;
     };
-
-    scrollWhenReady(index, firstCall) {
-        if (this.loading || firstCall) {
-            var that = this;
-            setTimeout(function () {
-                that.scrollWhenReady(index, false);
-            }, 200);
-        } else {
-            var that = this;
-            setTimeout(function () {
-                that.scrollToIndex(index);
-            }, 200);
-        }
-    };
-
 
     static get is() {
         /** prefix with vaadin because grid column requires this **/


### PR DESCRIPTION
1. `ParentItemProvider` has been removed, as the `HierarchicalDataProvider` interface now officially supports the `getParent` method. The only difference is that it's now expected to return `null` if the item doesn't have a parent, instead of an `Optional`:

    ```diff
    - public Optional<Department> getParent(Department item) {
    + public Department getParent(Department item) {
    ```

3. The `scrollToItem` feature has been removed from this addon, as it's now built into Vaadin's official TreeGrid component. Depending on the data provider type, it may require implementing `HierarchicalDataProvider#getParent` or/and `HierarchicalDataProvider#getItemIndex`:

    | DataProvider | isInMemory() | getItemIndex() | getParent()    |
    |:------------------|--------------|--------------|--------------|
    | TreeDataProvider             | true  | not required | not required |
    | HierarchicalDataProvider | true  | not required | required |
    | HierarchicalDataProvider | false | required       | required |

    When using in-memory hierarchical data providers, `getParent()` is still the only required method, however.


Follow-up to https://github.com/vaadin/platform/issues/7843